### PR TITLE
🔨 Add `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /Alternate-Entities-Faithful-32x.zip
-/scripts/run.bat
+/scripts/run.*
 
 # Created by https://www.toptal.com/developers/gitignore/api/windows,macos,linux,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos,linux,visualstudiocode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,4 @@
 {
+  "recommendations": ["foxundermoon.shell-format"],
   "unwantedRecommendations": ["ms-vscode-remote.remote-wsl"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,7 @@
 {
-  "recommendations": ["foxundermoon.shell-format"],
+  "recommendations": [
+    "foxundermoon.shell-format",
+    "github.vscode-pull-request-github"
+  ],
   "unwantedRecommendations": ["ms-vscode-remote.remote-wsl"]
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ $(basename $PWD) = "scripts" ]; then
+	cd ..
+fi
+
+rm Alternate-Entities-Faithful-32x.zip
+7z a -mmt6 -mx9 Alternate-Entities-Faithful-32x.zip assets LICENSE.txt pack.mcmeta pack.png


### PR DESCRIPTION
Adds a `build.sh` to enable building it in Linux. Depends on `7z`.